### PR TITLE
fix: update withdrawal modal to display connected wallet address (#80)

### DIFF
--- a/src/app/dashboard/components/payoutComponents/WithdrawModal.tsx
+++ b/src/app/dashboard/components/payoutComponents/WithdrawModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useAccount } from "@starknet-react/core";
 import { CheckCircle2, ChevronDown, ArrowLeft, User } from "lucide-react";
 import Image from "next/image";
 
@@ -11,6 +12,7 @@ export default function WithdrawModal({
   onSubmit: (amount: number, numAmount: number, usdEquivalent: number) => void;
   withdrawableBalance?: number;
 }) {
+  const { address, isConnected } = useAccount();
   const [amount, setAmount] = useState("");
   const [step, setStep] = useState(1);
   const [usdEquivalent, setUsdEquivalent] = useState(0);
@@ -46,6 +48,10 @@ export default function WithdrawModal({
     setUsdEquivalent(withdrawableBalance * 0.573);
   };
 
+  // Helper to truncate address nicely
+  const truncateAddress = (addr: string) =>
+    addr ? `${addr.slice(0, 6)}...${addr.slice(-4)}` : "";
+
   return (
     <div className="fixed inset-0 flex items-center justify-center z-50 p-4">
       <div className="fixed inset-0 bg-[#211a1d] bg-opacity-80 backdrop-blur-md"></div>
@@ -61,31 +67,31 @@ export default function WithdrawModal({
       {step === 1 && (
         <div className="relative bg-[#1b1618] border border-[#464043] rounded-2xl w-[95%] max-w-xl z-10 max-h-[90vh] overflow-y-auto">
           <div className="text-center pt-6 sm:pt-10 pb-4 sm:pb-6">
-            <h2 className="text-3xl sm:text-4xl font-bold text-white">
-              Withdraw
-            </h2>
+            <h2 className="text-3xl sm:text-4xl font-bold text-white">Withdraw</h2>
           </div>
 
           <div className="p-4 sm:p-6">
             {/* Recipient Section */}
             <div className="mb-4 sm:mb-6 bg-[#110D0F] border border-gray-800 rounded-2xl p-4 sm:p-6">
-              <h3 className="text-white text-lg sm:text-xl mb-3 sm:mb-4">
-                Recepient
-              </h3>
+              <h3 className="text-white text-lg sm:text-xl mb-3 sm:mb-4">Recipient</h3>
               <div className="flex items-center">
                 <User size={18} className="text-white mr-2" />
                 <div>
                   <div className="flex flex-col sm:flex-row sm:items-center">
                     <span className="text-white text-base sm:text-lg font-medium">
-                      0x0596....0f3
+                      {isConnected ? truncateAddress(address!) : "Wallet not connected"}
                     </span>
                     <span className="text-gray-500 sm:ml-2 text-xs sm:text-sm mt-1 sm:mt-0">
                       Account Address
                     </span>
                   </div>
                   <div className="flex items-center text-green-500 mt-1">
-                    <CheckCircle2 size={16} className="mr-2" />
-                    <span className="text-sm">Valid Address</span>
+                    {isConnected && (
+                      <>
+                        <CheckCircle2 size={16} className="mr-2" />
+                        <span className="text-sm">Valid Address</span>
+                      </>
+                    )}
                   </div>
                 </div>
               </div>
@@ -93,9 +99,7 @@ export default function WithdrawModal({
 
             {/* Amount Section */}
             <div className="mb-4 sm:mb-6 bg-[#110D0F] border border-gray-800 rounded-2xl p-4 sm:p-6">
-              <h3 className="text-white text-lg sm:text-xl mb-3 sm:mb-4">
-                Amount
-              </h3>
+              <h3 className="text-white text-lg sm:text-xl mb-3 sm:mb-4">Amount</h3>
 
               <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center mb-3 sm:mb-4 gap-2">
                 <input
@@ -147,7 +151,7 @@ export default function WithdrawModal({
                 parseFloat(amount) <= 0 ||
                 parseFloat(amount) > withdrawableBalance
                   ? "bg-gray-800 cursor-not-allowed"
-                  : "bg-[#0000FF] hover:bg-[#1100ff] "
+                  : "bg-[#0000FF] hover:bg-[#1100ff]"
               } text-white font-medium py-3 sm:py-4 rounded-lg transition-colors text-lg sm:text-xl`}
             >
               Withdraw
@@ -159,31 +163,31 @@ export default function WithdrawModal({
       {step === 2 && (
         <div className="relative bg-[#1b1618] border border-[#464043] rounded-2xl w-[95%] max-w-xl z-10 max-h-[90vh] overflow-y-auto">
           <div className="text-center pt-6 sm:pt-10 pb-4 sm:pb-6">
-            <h2 className="text-3xl sm:text-4xl font-bold text-white">
-              Withdraw
-            </h2>
+            <h2 className="text-3xl sm:text-4xl font-bold text-white">Withdraw</h2>
           </div>
 
           <div className="p-4 sm:p-6">
             {/* Recipient Section */}
             <div className="mb-4 sm:mb-6 bg-[#110D0F] border border-gray-800 rounded-2xl p-4 sm:p-6">
-              <h3 className="text-white text-lg sm:text-xl mb-3 sm:mb-4">
-                Recepient
-              </h3>
+              <h3 className="text-white text-lg sm:text-xl mb-3 sm:mb-4">Recipient</h3>
               <div className="flex items-center">
                 <User size={18} className="text-white mr-2" />
                 <div>
                   <div className="flex flex-col sm:flex-row sm:items-center">
                     <span className="text-white text-base sm:text-lg font-medium">
-                      0x0596....0f3
+                      {isConnected ? truncateAddress(address!) : "Wallet not connected"}
                     </span>
                     <span className="text-gray-500 sm:ml-2 text-xs sm:text-sm mt-1 sm:mt-0">
                       Account Address
                     </span>
                   </div>
                   <div className="flex items-center text-green-500 mt-1">
-                    <CheckCircle2 size={16} className="mr-2" />
-                    <span className="text-sm">Valid Address</span>
+                    {isConnected && (
+                      <>
+                        <CheckCircle2 size={16} className="mr-2" />
+                        <span className="text-sm">Valid Address</span>
+                      </>
+                    )}
                   </div>
                 </div>
               </div>
@@ -191,9 +195,7 @@ export default function WithdrawModal({
 
             {/* Amount Section */}
             <div className="mb-4 sm:mb-6 bg-[#110D0F] border border-gray-800 rounded-2xl p-4 sm:p-6">
-              <h3 className="text-white text-lg sm:text-xl mb-3 sm:mb-4">
-                Amount
-              </h3>
+              <h3 className="text-white text-lg sm:text-xl mb-3 sm:mb-4">Amount</h3>
               <div className="flex justify-between items-center mb-3 sm:mb-4">
                 <div className="text-white text-2xl sm:text-4xl font-bold">
                   {parseFloat(amount).toLocaleString()}

--- a/src/app/dashboard/researcher/rewards/page.tsx
+++ b/src/app/dashboard/researcher/rewards/page.tsx
@@ -1,117 +1,120 @@
 "use client";
 
 import { useState } from "react";
-import { Animation } from "@/motion/Animation";
-import { Wallet, DollarSign, History, ArrowLeft } from "lucide-react";
-import { RecentEarnings } from "@/components/dashboard/Recent-earnings";
-import { TransactionSuccessModal } from "@/components/dashboard/Transaction-success-modal";
-import { WithdrawalHistory } from "@/components/dashboard/Withdrawal-history";
-import { WithdrawalHistoryModal } from "@/components/dashboard/Withdrawal-history-modal";
-import { WithdrawalRequest } from "@/components/dashboard/Withdrawal-request";
-import { StatCard } from "../../components/resuables/StatsCard";
-import { useAccount } from "@starknet-react/core"; // ✅ Added
+import { CheckCircle2, ChevronDown, User } from "lucide-react";
+import Image from "next/image";
+import { useAccount } from "@starknet-react/core"; // ✅ Import StarkNet wallet hook
 
-export default function RewardPage() {
-  const [showSuccessModal, setShowSuccessModal] = useState(false);
-  const [showHistoryModal, setShowHistoryModal] = useState(false);
-  const [withdrawalAmount, setWithdrawalAmount] = useState<number | null>(null);
-  const [activeTab, setActiveTab] = useState<"rewards" | "withdraw">("rewards");
+export function WithdrawalRequest({
+  onSubmit,
+  withdrawableBalance = 11235.01,
+}: {
+  onSubmit: (amount: number, numAmount: number, usdEquivalent: number) => void;
+  withdrawableBalance?: number;
+}) {
+  const [amount, setAmount] = useState("");
+  const [usdEquivalent, setUsdEquivalent] = useState(0);
 
-  const { account } = useAccount(); // ✅ Get connected wallet address
+  const { account } = useAccount(); // ✅ Get connected account
 
-  const handleWithdrawalSubmit = (amount: number) => {
-    setWithdrawalAmount(amount);
-    setShowSuccessModal(true);
+  const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (/^\d*\.?\d*$/.test(value) || value === "") {
+      setAmount(value);
+      const numValue = parseFloat(value) || 0;
+      setUsdEquivalent(numValue * 0.573);
+    }
+  };
+
+  const handleSubmit = () => {
+    if (amount) {
+      const numAmount = parseFloat(amount);
+      onSubmit?.(numAmount, numAmount, usdEquivalent);
+    }
+  };
+
+  const handleMaxAmount = () => {
+    setAmount(withdrawableBalance.toString());
+    setUsdEquivalent(withdrawableBalance * 0.573);
   };
 
   return (
-    <div className="flex flex-col gap-6 md:p-6">
-      {/* ✅ Connected Wallet Display */}
-      <div className="text-white text-sm mb-2">
-        Connected Wallet:{" "}
-        {account?.address ? (
-          <span className="font-mono">
-            {account.address.slice(0, 6)}...{account.address.slice(-4)}
-          </span>
-        ) : (
-          <span className="text-gray-400">Not connected</span>
-        )}
+    <div className="bg-[#110D0F] border border-gray-800 rounded-2xl p-4 sm:p-6">
+      <h3 className="text-white text-lg sm:text-xl mb-3 sm:mb-4">
+        Recipient
+      </h3>
+      <div className="flex items-center">
+        <User size={18} className="text-white mr-2" />
+        <div>
+          <div className="flex flex-col sm:flex-row sm:items-center">
+            <span className="text-white text-base sm:text-lg font-medium">
+              {account?.address
+                ? `${account.address.slice(0, 6)}...${account.address.slice(-4)}`
+                : "Not connected"}
+            </span>
+            <span className="text-gray-500 sm:ml-2 text-xs sm:text-sm mt-1 sm:mt-0">
+              Account Address
+            </span>
+          </div>
+          <div className="flex items-center text-green-500 mt-1">
+            <CheckCircle2 size={16} className="mr-2" />
+            <span className="text-sm">Valid Address</span>
+          </div>
+        </div>
       </div>
 
-      {activeTab === "rewards" ? (
-        <>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <Animation delay={0.2} animationType="slide-up">
-              <StatCard
-                icon={<Wallet className="w-6 h-6 text-white" />}
-                value="2,500 STRK"
-                label="Total Rewards Earned:"
-              />
-            </Animation>
+      <h3 className="text-white text-lg sm:text-xl mb-3 sm:mb-4 mt-6">
+        Amount
+      </h3>
 
-            <Animation delay={0.3} animationType="slide-up">
-              <StatCard
-                icon={<DollarSign className="w-6 h-6 text-white" />}
-                value="150 STRK"
-                label="Pending Withdrawal"
-              />
-            </Animation>
-
-            <Animation delay={0.4} animationType="slide-up">
-              <button
-                className="p-5 bg-[#0000FF] rounded-[20px] w-full h-full border-[0.5px] border-[#464043] cursor-pointer flex items-center justify-center gap-5"
-                onClick={() => setActiveTab("withdraw")}
-              >
-                <span className="text-2xl font-bold text-white">
-                  Withdraw Funds
-                </span>
-                <span className="text-white text-xl">→</span>
-              </button>
-            </Animation>
-          </div>
-
-          <Animation delay={0.5} animationType="slide-up">
-            <div className="flex justify-end items-center mt-5 mb-5">
-              <button
-                className="flex gap-2 items-center text-white cursor-pointer"
-                onClick={() => setShowHistoryModal(true)}
-              >
-                <History className="w-5 h-5" />
-                <span>View Withdrawal History</span>
-              </button>
-            </div>
-            <RecentEarnings />
-          </Animation>
-        </>
-      ) : (
-        <Animation delay={0.2} animationType="fade-in">
-          <div className="flex flex-col gap-6">
-            <button
-              onClick={() => setActiveTab("rewards")}
-              className="flex items-center gap-3 text-white cursor-pointer"
-            >
-              <ArrowLeft />
-              <span>Go Back</span>
-            </button>
-            <WithdrawalRequest onSubmit={handleWithdrawalSubmit} />
-            <WithdrawalHistory />
-          </div>
-        </Animation>
-      )}
-
-      {showSuccessModal && withdrawalAmount && (
-        <TransactionSuccessModal
-          amount={withdrawalAmount}
-          onClose={() => {
-            setShowSuccessModal(false);
-            setActiveTab("rewards");
-          }}
+      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center mb-3 sm:mb-4 gap-2">
+        <input
+          type="text"
+          value={amount}
+          onChange={handleAmountChange}
+          placeholder="Enter Withdrawal Amount"
+          className="flex-1 min-w-0 bg-transparent text-white text-xl placeholder:text-gray-600 font-medium outline-none py-2"
         />
-      )}
+        <button className="bg-white text-black rounded-lg px-2 py-1 w-fit sm:px-3 sm:w-28 text-md sm:text-sm flex items-center justify-center">
+          <Image
+            src="/token-branded_starknet.svg"
+            alt="strk logo"
+            width={18}
+            height={18}
+            className="mr-1"
+          />
+          <span className="font-medium">STRK</span>
+          <ChevronDown size={18} className="ml-1" />
+        </button>
+      </div>
 
-      {showHistoryModal && (
-        <WithdrawalHistoryModal onClose={() => setShowHistoryModal(false)} />
-      )}
+      <div className="flex justify-between items-center mt-3 sm:mt-4">
+        <div className="text-gray-500 text-sm sm:text-base">
+          {amount && parseFloat(amount) > 0
+            ? `Approx. $${usdEquivalent.toFixed(2)}`
+            : ""}
+        </div>
+        <div className="flex items-center justify-between w-full">
+          <div className="invisible">Placeholder</div>
+          <div className="text-gray-500 text-sm sm:text-base">
+            Escrow Balance: {withdrawableBalance.toLocaleString()}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <button
+          onClick={handleSubmit}
+          disabled={!amount || parseFloat(amount) <= 0}
+          className={`w-full ${
+            !amount || parseFloat(amount) <= 0
+              ? "bg-gray-800 cursor-not-allowed"
+              : "bg-[#0000FF] hover:bg-[#1100ff]"
+          } text-white font-medium py-3 sm:py-4 rounded-lg transition-colors text-lg sm:text-xl`}
+        >
+          Withdraw
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/app/dashboard/researcher/rewards/page.tsx
+++ b/src/app/dashboard/researcher/rewards/page.tsx
@@ -9,12 +9,15 @@ import { WithdrawalHistory } from "@/components/dashboard/Withdrawal-history";
 import { WithdrawalHistoryModal } from "@/components/dashboard/Withdrawal-history-modal";
 import { WithdrawalRequest } from "@/components/dashboard/Withdrawal-request";
 import { StatCard } from "../../components/resuables/StatsCard";
+import { useAccount } from "@starknet-react/core"; // ✅ Added
 
 export default function RewardPage() {
   const [showSuccessModal, setShowSuccessModal] = useState(false);
   const [showHistoryModal, setShowHistoryModal] = useState(false);
   const [withdrawalAmount, setWithdrawalAmount] = useState<number | null>(null);
   const [activeTab, setActiveTab] = useState<"rewards" | "withdraw">("rewards");
+
+  const { account } = useAccount(); // ✅ Get connected wallet address
 
   const handleWithdrawalSubmit = (amount: number) => {
     setWithdrawalAmount(amount);
@@ -23,6 +26,18 @@ export default function RewardPage() {
 
   return (
     <div className="flex flex-col gap-6 md:p-6">
+      {/* ✅ Connected Wallet Display */}
+      <div className="text-white text-sm mb-2">
+        Connected Wallet:{" "}
+        {account?.address ? (
+          <span className="font-mono">
+            {account.address.slice(0, 6)}...{account.address.slice(-4)}
+          </span>
+        ) : (
+          <span className="text-gray-400">Not connected</span>
+        )}
+      </div>
+
       {activeTab === "rewards" ? (
         <>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">

--- a/src/components/dashboard/Withdrawal-request.tsx
+++ b/src/components/dashboard/Withdrawal-request.tsx
@@ -7,6 +7,7 @@ import { ChevronDown,  CircleCheck, User } from "lucide-react";
 import Image from "next/image";
 import CoinBag from "../../../public/researcherIcon/moneyBag.svg";
 import Starknet from "../../../public/researcherIcon/starknet.svg";
+import { useAccount } from "@starknet-react/core";
 
 interface WithdrawalRequestProps {
   onSubmit: (amount: number) => void;
@@ -82,9 +83,14 @@ export const WithdrawalRequest: React.FC<WithdrawalRequestProps> = ({
                   <User className="w-8 h-8" />
                   <div>
                     <div className="flex items-center gap-2 mb-2">
-                      <span className="text-white text-xl">{address}</span>
                       <span className="text-[#6B6668] text-[10px]">
-                        Account Address
+                        <span className="text-white text-xl">
+                       {account?.address
+                        ? `${account.address.slice(0, 6)}...${account.address.slice(-4)}`
+                        : "Not connected"}
+                        </span>
+
+                       Account Address
                       </span>
                     </div>
                     {isAddressValid && (


### PR DESCRIPTION
This PR fixes issue #80 by updating the withdrawal modal to display the currently connected wallet address dynamically instead of a static placeholder.

- Uses useAccount() from @starknet-react/core to get the connected wallet address
- Shows fallback text if no wallet connected
- Formats the address for better readability

This improves the user experience by accurately showing the connected wallet in the withdrawal process.
