### PR TITLE
Fix: Display Correct Wallet Address in Withdraw Modal

### DIFF
--- a/src/app/dashboard/components/payoutComponents/WithdrawModal.tsx
+++ b/src/app/dashboard/components/payoutComponents/WithdrawModal.tsx
@@ -6,10 +6,12 @@ export default function WithdrawModal({
   onClose,
   onSubmit,
   withdrawableBalance = 11235.01,
+  walletAddress,
 }: {
   onClose: () => void;
   onSubmit: (amount: number, numAmount: number, usdEquivalent: number) => void;
   withdrawableBalance?: number;
+  walletAddress: string
 }) {
   const [amount, setAmount] = useState("");
   const [step, setStep] = useState(1);
@@ -77,7 +79,7 @@ export default function WithdrawModal({
                 <div>
                   <div className="flex flex-col sm:flex-row sm:items-center">
                     <span className="text-white text-base sm:text-lg font-medium">
-                      0x0596....0f3
+                     {walletAddress && `${walletAddress.slice(0,6)}...${walletAddress.slice(-4)}`}
                     </span>
                     <span className="text-gray-500 sm:ml-2 text-xs sm:text-sm mt-1 sm:mt-0">
                       Account Address
@@ -175,7 +177,7 @@ export default function WithdrawModal({
                 <div>
                   <div className="flex flex-col sm:flex-row sm:items-center">
                     <span className="text-white text-base sm:text-lg font-medium">
-                      0x0596....0f3
+                      {walletAddress}
                     </span>
                     <span className="text-gray-500 sm:ml-2 text-xs sm:text-sm mt-1 sm:mt-0">
                       Account Address

--- a/src/app/dashboard/project-owner/payouts/page.tsx
+++ b/src/app/dashboard/project-owner/payouts/page.tsx
@@ -11,6 +11,7 @@ import { motion } from "framer-motion";
 
 import Image from "next/image";
 import { useTokenBalance } from "@/hooks/useTokenBalance";
+import {useAccount} from "@starknet-react/core"
 
 export default function PayoutPage() {
   const [isEscrowModalOpen, setIsEscrowModalOpen] = useState(false);
@@ -45,6 +46,7 @@ export default function PayoutPage() {
   const handleCloseWithdrawSuccessModal = () => {
     setIsWithdrawSuccessModalOpen(false);
   };
+  const {address} = useAccount()
 
   const cardVariants = {
     hidden: { opacity: 0, y: 50 },
@@ -246,6 +248,7 @@ export default function PayoutPage() {
           onClose={() => setIsWithdrawModalOpen(false)}
           onSubmit={handleWithdraw}
           withdrawableBalance={243.21}
+          walletAddress={address ?? ""}
         />
       )}
 


### PR DESCRIPTION

  This PR updates the recipient section in the first step of the `WithdrawModal` component to use the
     `walletAddress` prop. It now displays a shortened version of the user's actual wallet address, ensuring
     consistency and correctness throughout the withdrawal process.


![forechain-2](https://github.com/user-attachments/assets/1d1147c6-12a3-4646-9c31-e031ae8a8b85)
![forechain](https://github.com/user-attachments/assets/2087f97b-291b-4af1-b7b8-6c5fadc56e3f)
